### PR TITLE
fix build dependencies

### DIFF
--- a/fontconfig-infinality-remix/PKGBUILD
+++ b/fontconfig-infinality-remix/PKGBUILD
@@ -18,7 +18,7 @@ arch=('i686' 'x86_64')
 groups=('infinality-remix')
 
 depends=('expat' 'freetype2')
-makedepends=('gperf' 'python-lxml' 'python-six')
+makedepends=('gperf' 'python-lxml' 'python-six' 'git')
 options=('libtool')
 
 provides=('fontconfig=$pkgver' 'fontconfig-infinality-remix')

--- a/freetype2-infinality-remix/PKGBUILD
+++ b/freetype2-infinality-remix/PKGBUILD
@@ -18,7 +18,7 @@ url="http://www.freetype.org/"
 
 # Adding harfbuzz for improved OpenType features auto-hinting
 # introduces a cycle dep to harfbuzz depending on freetype wanted by upstream
-makedepends=('libx11')
+makedepends=('libx11' 'libpng' 'harfbuzz')
 
 install=freetype2.install
 


### PR DESCRIPTION
`git` is a required makedepends for fontconfig-infinality-remix.

Without `libpng` and `harfbuzz` in makedepends for freetype2-infinality-remix build fails in clean chroots.